### PR TITLE
Add episode timings

### DIFF
--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -1,6 +1,6 @@
 ---
 title: "Introduction"
-teaching: 30
+teaching: 5
 exercises: 0
 questions:
 - "What sort of scientific questions can we answer with image processing / 

--- a/_episodes/02-image-basics.md
+++ b/_episodes/02-image-basics.md
@@ -1,7 +1,7 @@
 ---
 title: "Image Basics"
-teaching: 30
-exercises: 0
+teaching: 35
+exercises: 15
 questions:
 - "How are images represented in digital format?"
 objectives:
@@ -151,7 +151,7 @@ integers in [0, 255], representing the red, green, and blue channels,
 respectively. A larger number in a channel means that more of that primary 
 color is present. 
 
-> ## Thinking about RGB colors
+> ## Thinking about RGB colors (3 min)
 > 
 > Suppose that we represent colors as triples (r, g, b), where each of r, g, 
 > and b is an integer in [0, 255]. What colors are represented by each of these
@@ -183,7 +183,7 @@ After completing the previous challenge, we can look at some further examples
 of 24-bit RGB colors, in a visual way. The image in the next challenge shows 
 some color names, their 24-bit RGB triplet values, and the color itself.
 
-> ## RGB color table
+> ## RGB color table (4 min)
 > 
 > ![RGB color table](../fig/01-color-table.png)
 > 
@@ -261,7 +261,7 @@ the concept.
 
 Let's begin our discussion of compression with a simple challenge. 
 
-> ## BMP image size
+> ## BMP image size (8 min)
 > 
 > Imagine that we have a fairly large, but very boring image: a 5,000 × 5,000 
 > pixel image composed of nothing but white pixels. If we used an uncompressed 

--- a/_episodes/03-opencv-images.md
+++ b/_episodes/03-opencv-images.md
@@ -1,7 +1,7 @@
 ---
 title: "OpenCV Images"
 teaching: 30
-exercises: 0
+exercises: 70
 questions:
 - "How are digital images stored in Python with the OpenCV computer vision library?"
 objectives:
@@ -166,7 +166,7 @@ program will pause for that many milliseconds, and then continue automatically.
 > functions we will cover in this workshop. 
 {: .callout}
 
-> ## Experimenting with windows
+> ## Experimenting with windows (3 min)
 > 
 > Creating a named window before calling the `imshow()` function is optional.
 > Navigate to the **Desktop/workshops/image-processing/03-opencv-images**
@@ -188,7 +188,7 @@ program will pause for that many milliseconds, and then continue automatically.
 > {: .solution}
 {: .challenge}
 
-> ## Resizing an image
+> ## Resizing an image (20 min)
 > 
 > Using your mobile phone, tablet, web cam, or digital camera, take an image.
 > Copy the image to the **Desktop/workshops/image-processing/03-opencv-images**
@@ -324,7 +324,7 @@ extraneous background detail has been removed.
 
 ![Thresholded root image](../fig/02-roots-threshold.jpg)
 
-> ## Keeping only low intensity pixels
+> ## Keeping only low intensity pixels (20 min)
 > 
 > In the previous example, we showed how we could use Python and OpenCV to turn
 > on only the high intensity pixels from an image, while turning all the low 
@@ -452,7 +452,7 @@ the program:
 
 !["Erased" whiteboard](../fig/02-board-final.jpg)
 
-> ## Practicing with slices
+> ## Practicing with slices (10 min)
 > 
 > Navigate to the **Desktop/workshops/image-processing/03-opencv-images** 
 > directory, and edit the **RootSlice.py** program. It contains a skeleton
@@ -494,7 +494,7 @@ the program:
 > {: .solution}
 {: .challenge}
 
-> ## Metadata, continued
+> ## Metadata, continued (10 min)
 > Let us return to the concept of image metadata, introduced briefly in the
 > [Image Basics]({{ page.root }}/02-image-basics/) episode. Specifically, what
 > happens to the metadata of an image when it is read into, and written from,
@@ -566,7 +566,7 @@ the program:
 > {: .solution}
 {: .challenge}
 
-> ## Slicing and the colorimetric challenge
+> ## Slicing and the colorimetric challenge (10 min)
 > 
 > In the [introductory]({{page.root}}/01-introduction/) episode, we were 
 > introduced to a colorimetric challenge, namely, graphing the color values of

--- a/_episodes/04-drawing-bitwise.md
+++ b/_episodes/04-drawing-bitwise.md
@@ -1,7 +1,7 @@
 ---
 title: "Drawing and Bitwise Operations"
-teaching: 30
-exercises: 0
+teaching: 20
+exercises: 60
 questions:
 - "How can we draw on OpenCV images and use bitwise operations and masks to 
 select certain parts of an image?"
@@ -134,7 +134,7 @@ Here's what our constructed mask looks like:
 
 ![Maize image mask](../fig/03-maize-mask.png)
 
-> ## Other drawing operations
+> ## Other drawing operations (10 min)
 > 
 > There are other functions for drawing on images, in addition to the 
 > `cv2rectangle()` function. We can draw circles, lines, text, and other shapes as
@@ -301,7 +301,7 @@ this:
 
 ![Applied mask](../fig/03-applied-mask.jpg)
 
-> ## Masking an image of your own
+> ## Masking an image of your own (optional)
 > 
 > Now, it is your turn to practice. Using your mobile phone, tablet, webcam, or
 > digital camera, take an image of an object with a simple overall geometric 
@@ -354,7 +354,7 @@ this:
 > {: .solution}
 {: .challenge}
 
-> ## Masking a 96-well plate image
+> ## Masking a 96-well plate image (50 min)
 > 
 > Consider this image of a 96-well plate that has been scanned on a flatbed 
 > scanner. 
@@ -428,7 +428,7 @@ this:
 > {: .solution}
 {: .challenge}
 
-> ## Masking a 96-well plate image, take two
+> ## Masking a 96-well plate image, take two (optional)
 > 
 > If you spent some time looking at the contents of the **centers.txt** file
 > from the previous challenge, you may have noticed that the centers of each

--- a/_episodes/05-creating-histograms.md
+++ b/_episodes/05-creating-histograms.md
@@ -1,7 +1,7 @@
 ---
 title: "Creating Histograms"
-teaching: 30
-exercises: 0
+teaching: 25
+exercises: 60
 questions:
 - "How can we create grayscale and color histograms to understand the 
 distribution of color values in an image?"
@@ -161,7 +161,7 @@ the program produces this histogram:
 
 ![Plant seedling histogram](../fig/04-plant-seedling-gs-histogram.png)
 
-> ## Using a mask for a histogram
+> ## Using a mask for a histogram (25 min)
 > 
 > Looking at the histogram above, you will notice that there is a large number
 > of very dark pixels, as indicated in the chart by the spike around the 
@@ -389,7 +389,7 @@ Finally we label our axes and display the histogram, shown here:
 
 ![Color histogram](../fig/04-plant-seedling-histogram.png)
 
-> ## Color histogram with a mask
+> ## Color histogram with a mask (25 min)
 > 
 > We can also apply a mask to the images we apply the color histogram process
 > to, in the same way we did for grayscale histograms. Consider this image of a
@@ -499,7 +499,7 @@ Finally we label our axes and display the histogram, shown here:
 > {: .solution}
 {: .challenge}
 
-> ## Histograms for the morphometrics challenge
+> ## Histograms for the morphometrics challenge (10 min)
 > 
 > Using the grayscale and color histogram programs we developed in this episode,
 > create histograms for the bacteria colonies in the 

--- a/_episodes/06-blurring.md
+++ b/_episodes/06-blurring.md
@@ -1,7 +1,7 @@
 ---
 title: "Blurring images"
-teaching: 30
-exercises: 0
+teaching: 10
+exercises: 40
 questions:
 - "How can we apply a low-pass blurring filter to an image?"
 objectives:
@@ -195,7 +195,7 @@ kernel size. This is done with the
 line of code. The `int()` function takes a string as its parameter, and returns 
 the integer equivalent. 
 
-> ## What happens if the `int()` parameter does not look like a number?
+> ## What happens if the `int()` parameter does not look like a number? (10 min)
 > 
 > In the preceding program, we are using the `int()` function to *parse* the
 > second command-line argument, which comes in to the program as a string, 
@@ -292,7 +292,7 @@ applying a filter with a kernel size of seven.
 
 ![Gaussian blurred image](../fig/05-gaussian-blurred.png)
 
-> ## Experimenting with kernel size
+> ## Experimenting with kernel size (5 min)
 > 
 > Navigate to the **Desktop/workshops/image-processing/06-blurring** directory
 > and execute the **GaussBlur.py** script, which contains the program shown
@@ -320,7 +320,7 @@ applying a filter with a kernel size of seven.
 > {: .solution}
 {: .challenge}
 
-> ## Experimenting with kernel shape
+> ## Experimenting with kernel shape (10 min)
 > 
 > Now, modify the **GaussBlur.py** program so that it takes *three*
 > command-line parameters instead of two. The first parameter should still be
@@ -381,7 +381,7 @@ for images with Gaussian (i.e., random) noise, median blurring for removing
 "salt and pepper" or "static" noise, and bilateral blurring when we want to 
 preserve sharp edges. 
 
-> ## Blurring the bacteria colony images
+> ## Blurring the bacteria colony images (15 min)
 > 
 > As we move further into the workshop, we will see that in order to complete
 > the colony-counting morphometric challenge at the end, we will need to read

--- a/_episodes/07-thresholding.md
+++ b/_episodes/07-thresholding.md
@@ -1,7 +1,7 @@
 ---
 title: "Thresholding"
 teaching: 30
-exercises: 0
+exercises: 65
 questions:
 - "How can we use thresholding to produce a binary image?"
 objectives:
@@ -197,7 +197,7 @@ colored shapes from the original, as shown in this image:
 
 ![Selected shapes](../fig/06-junk-selected.jpg)
 
-> ## More practice with simple thresholding
+> ## More practice with simple thresholding (15 min)
 > 
 > Now, it is your turn to practice. Suppose we want to use simple thresholding
 > to select only the colored shapes from this image: 
@@ -610,7 +610,7 @@ bash rootmass.sh > rootmass.csv
 ~~~
 {: .bash}
 
-> ## Ignoring more of the images -- brainstorming
+> ## Ignoring more of the images -- brainstorming (10 min)
 > 
 > Let us take a closer look at the binary images produced by the 
 > proceeding program. 
@@ -652,7 +652,7 @@ bash rootmass.sh > rootmass.csv
 > {: .solution}
 {: .challenge}
 
-> ## Ignoring more of the images -- implementation
+> ## Ignoring more of the images -- implementation (30 min)
 > 
 > Navigate to the **Desktop/workshops/image-processing/07-thresholding** 
 > directory, and edit the **RootMassImproved.py** program. This is a copy of 
@@ -746,7 +746,7 @@ bash rootmass.sh > rootmass.csv
 > {: .solution}
 {: .challenge}
 
-> ## Thresholding a bacteria colony image
+> ## Thresholding a bacteria colony image (10 min)
 > 
 > In the **Desktop/workshops/image-processing/07-thresholding** directory, you 
 > will find an image named **colonies01.tif**; this is one of the images you

--- a/_episodes/08-edge-detection.md
+++ b/_episodes/08-edge-detection.md
@@ -1,7 +1,7 @@
 ---
 title: "Edge Detection"
-teaching: 30
-exercises: 0
+teaching: 20
+exercises: 45
 questions:
 - "How can we automatically detect the edges of the objects in an image?"
 objectives:
@@ -380,7 +380,7 @@ shows the edges in an output file.
 
 ![Beads edges (file)](../fig/07-beads-out.jpg)
 
-> ## Applying Canny edge detection to another image
+> ## Applying Canny edge detection to another image (5 min)
 > 
 > Now, navigate to the **Desktop/workshops/image-processing/08-edge-detection**
 > directory, and run the **CannyTrack.py** program on the image of colored 
@@ -400,7 +400,7 @@ shows the edges in an output file.
 > {: .solution}
 {: .challenge}
 
-> ## Using trackbars for thresholding
+> ## Using trackbars for thresholding (40 min)
 > 
 > Now, let us apply what we know about creating trackbars to another, similar
 > situation. Consider this image of a collection of maize seedlings, and 


### PR DESCRIPTION
Adds episode timings for all episodes except contours. Based on episode timings listed in https://github.com/mmeysenburg/image-processing/issues/1, but with some adjustments to make times more well rounded. I marked exercises that were skipped during this workshop as "optional". 